### PR TITLE
Check if ['insecure'] isset and value to define insecure curl call

### DIFF
--- a/src/PhpProbe/Adapter/PhpCurlAdapter.php
+++ b/src/PhpProbe/Adapter/PhpCurlAdapter.php
@@ -71,7 +71,7 @@ class PhpCurlAdapter extends AbstractAdapter implements AdapterInterface
         curl_setopt($curlHandler, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curlHandler, CURLOPT_HEADER, 0);
         curl_setopt($curlHandler, CURLOPT_HTTPHEADER, $parameters['headers']);
-        if ($parameters['insecure']) {
+        if (isset($parameters['insecure']) && $parameters['insecure']) {
             curl_setopt($curlHandler, CURLOPT_SSL_VERIFYHOST, 0);
             curl_setopt($curlHandler, CURLOPT_SSL_VERIFYPEER, false);
         }


### PR DESCRIPTION
When probing a non-https url, the index insecure errors as not being defined. This update checks to see if the $parameters['insecure'] is set and its value to determine if the curl call is insecure.

**Sample Probe from PHP-PROBE-WEBAPP throwing exception**
```yaml
probes:
  Google.com_HTTP:
    type: Http
    options:
      url: http://www.google.com
      timeout: 5
    checkers:
      http:
        httpCode: 302
```
**Error**
```
2018/11/13 20:43:43 [error] 37#37: *1 FastCGI sent in stderr: "PHP message: PHP Notice:  Undefined inde